### PR TITLE
remove broken submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,9 +22,6 @@
 [submodule "sample/widgets/weather"]
 	path = sample/widgets/weather
 	url = https://github.com/angular-dashboard-framework/adf-widget-weather
-[submodule "sample/structures/base"]
-	path = sample/structures/base
-	url = https://github.com/angular-dashboard-framework/adf-structures-base
 [submodule "sample/widgets/travis"]
 	path = sample/widgets/travis
 	url = https://github.com/angular-dashboard-framework/adf-widget-travis


### PR DESCRIPTION
This fixes npm install breaking on newer versions of npm, the submodule isn't used in anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aquicore/angular-dashboard-framework/15)
<!-- Reviewable:end -->
